### PR TITLE
Fix typo

### DIFF
--- a/src/change-case.js
+++ b/src/change-case.js
@@ -40,7 +40,7 @@ export default class ChangeCase {
             'localeLowerCase': 'localé lower casé',
             'localeUpperCase': 'LöCALE UPPER CASE',
             'sentenceCase': 'Sentence case',
-            'toggleCase': 'tOOGLE cASE'
+            'toggleCase': 'tOGGLE cASE'
         }
     }
 


### PR DESCRIPTION
I noticed the name "tOOGLE cASE", I think it's meant to be "tOGGLE cASE".