### PR TITLE
Working fix for Safari, using 'mousedown' event instead of 'click'

### DIFF
--- a/src/change-case.js
+++ b/src/change-case.js
@@ -148,7 +148,7 @@ export default class ChangeCase {
 
         for (const btnOption of this.optionButtons) {
             this.actions.appendChild(btnOption);
-            this.api.listeners.on(btnOption, 'click', () => {
+            this.api.listeners.on(btnOption, 'mousedown', () => {
                 this.convertCase(this.range, btnOption.dataset.mode)
             });
         }
@@ -159,7 +159,7 @@ export default class ChangeCase {
 
     destroy() {
         for (const btnOption of this.optionButtons) {
-            this.api.listeners.off(btnOption, 'click');
+            this.api.listeners.off(btnOption, 'mousedown');
         }
     }
 }


### PR DESCRIPTION
As mentioned in #3, Safari seems to not trigger the event function properly. 
However, simply changing the event type to 'mousedown' from 'click' did the trick!